### PR TITLE
Using RTree to select features for tiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "accurate"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f209f0bc218ee6cf50db56ec0d9fe10b3cbfb6f3900d019b36c8fdb6d3bc03e"
-dependencies = [
- "cfg-if",
- "ieee754",
- "num-traits",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,15 +485,6 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
@@ -529,17 +509,18 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "geo"
-version = "0.23.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39f57e9624b1a17ce621375464e9878c705d0aaadaf25cb44e4e0005a16de2f"
+checksum = "a5d07d2288645058f3c78bc64eadd615335791cd5adb632e9865840afbc13dad"
 dependencies = [
- "float_next_after 0.1.5",
+ "earcutr",
+ "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "log",
  "num-traits",
  "robust 0.2.3",
- "rstar 0.9.3",
+ "rstar 0.10.0",
 ]
 
 [[package]]
@@ -549,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1645cf1d7fea7dac1a66f7357f3df2677ada708b8d9db8e9b043878930095a96"
 dependencies = [
  "earcutr",
- "float_next_after 1.0.0",
+ "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "log",
@@ -566,8 +547,8 @@ checksum = "9705398c5c7b26132e74513f4ee7c1d7dafd786004991b375c172be2be0eecaa"
 dependencies = [
  "approx",
  "num-traits",
+ "rstar 0.10.0",
  "rstar 0.11.0",
- "rstar 0.9.3",
  "serde",
 ]
 
@@ -577,7 +558,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea804e7bd3c6a4ca6a01edfa35231557a8a81d4d3f3e1e2b650d028c42592be"
 dependencies = [
- "accurate",
  "lazy_static",
 ]
 
@@ -663,12 +643,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "ieee754"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
@@ -1165,9 +1139,9 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rstar"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
 dependencies = [
  "heapless",
  "num-traits",
@@ -1372,7 +1346,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fs-err",
- "geo 0.23.1",
+ "geo 0.25.1",
  "geo-types",
  "geojson 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mvt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "accurate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f209f0bc218ee6cf50db56ec0d9fe10b3cbfb6f3900d019b36c8fdb6d3bc03e"
+dependencies = [
+ "cfg-if",
+ "ieee754",
+ "num-traits",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +496,15 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
@@ -509,18 +529,33 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "geo"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39f57e9624b1a17ce621375464e9878c705d0aaadaf25cb44e4e0005a16de2f"
+dependencies = [
+ "float_next_after 0.1.5",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust 0.2.3",
+ "rstar 0.9.3",
+]
+
+[[package]]
+name = "geo"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1645cf1d7fea7dac1a66f7357f3df2677ada708b8d9db8e9b043878930095a96"
 dependencies = [
  "earcutr",
- "float_next_after",
+ "float_next_after 1.0.0",
  "geo-types",
  "geographiclib-rs",
  "log",
  "num-traits",
- "robust",
- "rstar",
+ "robust 1.1.0",
+ "rstar 0.11.0",
 ]
 
 [[package]]
@@ -531,7 +566,8 @@ checksum = "9705398c5c7b26132e74513f4ee7c1d7dafd786004991b375c172be2be0eecaa"
 dependencies = [
  "approx",
  "num-traits",
- "rstar",
+ "rstar 0.11.0",
+ "rstar 0.9.3",
  "serde",
 ]
 
@@ -541,6 +577,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea804e7bd3c6a4ca6a01edfa35231557a8a81d4d3f3e1e2b650d028c42592be"
 dependencies = [
+ "accurate",
  "lazy_static",
 ]
 
@@ -626,6 +663,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
@@ -857,7 +900,7 @@ dependencies = [
  "csv",
  "fast_paths",
  "fs-err",
- "geo",
+ "geo 0.26.0",
  "geojson 0.24.1 (git+https://github.com/georust/geojson)",
  "indicatif",
  "itertools 0.11.0",
@@ -866,7 +909,7 @@ dependencies = [
  "num_cpus",
  "osmpbf",
  "rayon",
- "rstar",
+ "rstar 0.11.0",
  "serde",
  "serde_json",
 ]
@@ -1110,9 +1153,26 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "robust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
+
+[[package]]
+name = "robust"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
 
 [[package]]
 name = "rstar"
@@ -1312,10 +1372,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fs-err",
+ "geo 0.23.1",
+ "geo-types",
  "geojson 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mvt",
  "pmtiles2",
  "pointy",
+ "rstar 0.11.0",
  "serde_json",
 ]
 

--- a/tippe/Cargo.toml
+++ b/tippe/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 fs-err = "2.9.0"
-geojson = "0.24.1"
+geo = "0.23.1"
+geo-types = "0.7.8"
+geojson = {version= "0.24.1", features=["geo-types"]}
 mvt = "0.8.1"
 pmtiles2 = "0.2.0"
 pointy = "0.4.0"
+rstar = "0.11.0"
 serde_json = "1.0.107"

--- a/tippe/Cargo.toml
+++ b/tippe/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 fs-err = "2.9.0"
-geo = "0.23.1"
+geo = "0.25.0"
 geo-types = "0.7.8"
 geojson = {version= "0.24.1", features=["geo-types"]}
 mvt = "0.8.1"

--- a/tippe/src/main.rs
+++ b/tippe/src/main.rs
@@ -20,8 +20,9 @@ struct TreeFeature {
 
 impl From<geojson::Feature> for TreeFeature {
     fn from(feature: geojson::Feature) -> Self {
-        let properties = feature.properties.clone();
-        let mut geometry: geo_types::Geometry<f64> = feature.try_into().unwrap();
+        let properties = feature.properties;
+        // Geometry must exist
+        let mut geometry: geo_types::Geometry<f64> = feature.geometry.unwrap().try_into().unwrap();
         geometry.map_coords_in_place(|p| math::wgs84_to_web_mercator([p.x, p.y]).into());
         return Self {
             properties,

--- a/tippe/src/math.rs
+++ b/tippe/src/math.rs
@@ -27,6 +27,14 @@ pub struct BBox {
 }
 
 impl BBox {
+    pub fn new(min_lon: f64, min_lat: f64, max_lon: f64, max_lat: f64) -> Self {
+        Self {
+            min_lon,
+            min_lat,
+            max_lon,
+            max_lat,
+        }
+    }
     pub fn from_geojson(features: &Vec<Feature>) -> Self {
         // TODO Convert to geo and just use something there?
         let mut bbox = BBox {


### PR DESCRIPTION
This PR 

- Adds RStar, geo and geo_types as a dependencies 
- Generates an RTree in webmercator space and inserts objects representing the features
- Queries the RTree to get the potential contents of a given tile
-  Populates the tiles by iterating over the and selecting the contents 

I think it basically works, there are a few potential optimizations

1. Currently we are iterating over all possible tiles in each zoom level. It should be able to exclude ranges of tiles based on the  bbox of the lowest level envelope in the RTree 
2. There is a copy in the conversion of geo_json::Feature to TreeFeature which I think can be removed 
3. We should be able to exclude the child tiles of an empty tile from processing. If a level 2 tile is empty then it's descendants will be too. This might be a marginal speed up though as the RTree should already catch this