### PR TITLE
Make a tool to dump GeoJSON with a full network and its LTS and costs…

### DIFF
--- a/od2net/Cargo.toml
+++ b/od2net/Cargo.toml
@@ -2,6 +2,11 @@
 name = "od2net"
 version = "0.1.0"
 edition = "2021"
+default-run = "main"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.75"

--- a/od2net/src/bin/dump_network.rs
+++ b/od2net/src/bin/dump_network.rs
@@ -1,0 +1,32 @@
+use anyhow::{bail, Result};
+
+/// This tool writes `network.geojson` with the OSM tags, LTS, and cost for every edge in a
+/// network. No counts are calculated or included.
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        bail!("Call this with a config.json file");
+    }
+    let config_path = &args[1];
+    let config_json = fs_err::read_to_string(config_path)?;
+    let mut config: od2net::config::InputConfig = match serde_json::from_str(&config_json) {
+        Ok(config) => config,
+        Err(err) => bail!("{config_path} is invalid: {err}"),
+    };
+
+    // Assume the config file is in the directory for the area
+    let absolute_path = std::fs::canonicalize(config_path).unwrap();
+    let directory = absolute_path.parent().unwrap().display();
+    let osm_pbf_path = format!("{directory}/input/input.osm.pbf");
+
+    let mut timer = od2net::timer::Timer::new();
+    let network = od2net::network::Network::make_from_osm(
+        &fs_err::read(osm_pbf_path)?,
+        &config.lts,
+        &mut config.cost,
+        &mut timer,
+    )?;
+
+    fs_err::write("network.geojson", &network.to_debug_geojson()?)?;
+    Ok(())
+}


### PR DESCRIPTION
…, but no counts

You can use this to dump all edges for England by:
1) `cd examples/england_2011_home_to_work`
2) Modify `config.json` if you want different LTS or cost definitions
3) `python3 setup.py` or just make sure `input/input.osm.pbf` exists
3) `cargo run --release --bin dump_network config.json`
4) Use `network.geojson`