### PR TITLE
Use real OD data for Lisbon. #56

### DIFF
--- a/examples/lisbon/config.json
+++ b/examples/lisbon/config.json
@@ -1,9 +1,14 @@
 {
   "requests": {
     "description": "One trip from every building to the nearest (as the crow flies) school. Elevation is included.",
-    "pattern": "FromEveryOriginToNearestDestination",
+    "pattern": {
+      "BetweenZones": {
+        "zones_path": "zones.geojson",
+        "csv_path": "od.csv"
+      }
+    },
     "origins_path": "buildings.geojson",
-    "destinations_path": "schools.geojson"
+    "destinations_path": "buildings.geojson"
   },
   "cost": {
     "OsmHighwayType": {

--- a/examples/lisbon/setup.py
+++ b/examples/lisbon/setup.py
@@ -38,11 +38,21 @@ def makeOrigins():
 
 
 def makeDestinations():
-    # School centroids as destinations
-    extractCentroids(
-        osmInput="input/input.osm.pbf",
-        geojsonOutput="input/schools.geojson",
-        where=f"amenity = 'school'",
+    # Same as origins
+    pass
+
+
+def makeZones():
+    download(
+        url="https://github.com/U-Shift/biclar/releases/download/0.0.1/zones.geojson",
+        outputFilename="input/zones.geojson",
+    )
+
+
+def makeOD():
+    download(
+        url="https://github.com/U-Shift/biclar/releases/download/0.0.1/od.csv",
+        outputFilename="input/od.csv",
     )
 
 
@@ -53,3 +63,5 @@ if __name__ == "__main__":
     makeElevation()
     makeOrigins()
     makeDestinations()
+    makeZones()
+    makeOD()

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -23,6 +23,7 @@ def download(url, outputFilename):
     run(
         [
             "curl",
+            "-L",
             url,
             "-o",
             outputFilename,


### PR DESCRIPTION
The pre-built file on https://od2net.org is updated. After downloading the files, `cargo run --release config.json` took 67s for me, with 45s of that being tippecanoe to make pmtiles for visualization. Routing for the 875k trips took 18s on 19 cores.

![image](https://github.com/Urban-Analytics-Technology-Platform/od2net/assets/1664407/7a608f03-7456-451d-afb6-f6b9c3a8f6f2)

CC @temospena, thanks for the OD data! Let me know if you have any questions or if it'd be useful to have a call to chat about any of this