### PR TITLE
Implement weighted points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -654,12 +654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-
-[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,9 +698,9 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "lts",
- "nanorand",
  "num_cpus",
  "osm-reader",
+ "rand",
  "rayon",
  "rstar",
  "serde",
@@ -749,6 +743,15 @@ name = "portable-atomic"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "priority-queue"
@@ -829,6 +832,32 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -1348,6 +1377,7 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/od2net/Cargo.toml
+++ b/od2net/Cargo.toml
@@ -19,8 +19,8 @@ itertools = "0.12.1"
 log = "0.4.21"
 lts = { path = "../lts" }
 osm-reader = { git = "https://github.com/a-b-street/osm-reader", features = ["serde"] }
-nanorand = { version = "0.7.0", default-features = false, features = ["wyrand"] }
 num_cpus = "1.16.0"
+rand = { version = "0.8.5", default-features = false, features = ["alloc", "std_rng"] }
 rayon = "1.9.0"
 rstar = "0.12.0"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/od2net/src/config.rs
+++ b/od2net/src/config.rs
@@ -45,9 +45,11 @@ pub enum ODPattern {
         /// Path to a CSV file that must have 3 columns "from", "to", and "count". The first
         /// two must match zone names. "count" must be an integer.
         csv_path: String,
-        /// If a zone doesn't have any matching origin points, use the zone's centroid instead.
+        /// If a zone doesn't have any matching origin points, use the zone's centroid instead. The
+        /// centroid weight will be 1.
         origin_zone_centroid_fallback: bool,
-        /// If a zone doesn't have any matching destination points, use the zone's centroid instead.
+        /// If a zone doesn't have any matching destination points, use the zone's centroid
+        /// instead. The centroid weight will be 1.
         destination_zone_centroid_fallback: bool,
     },
     ZoneToPoint {
@@ -58,7 +60,8 @@ pub enum ODPattern {
         csv_path: String,
         /// Path to a GeoJSON file containing Points with a "name" property
         destinations_path: String,
-        /// If a zone doesn't have any matching origin points, use the zone's centroid instead.
+        /// If a zone doesn't have any matching origin points, use the zone's centroid instead. The
+        /// centroid weight will be 1.
         origin_zone_centroid_fallback: bool,
     },
     /// Just read GeoJSON LineStrings from this path

--- a/od2net/src/network/create_from_osm.rs
+++ b/od2net/src/network/create_from_osm.rs
@@ -255,8 +255,7 @@ fn split_edges(nodes: HashMap<NodeID, Position>, ways: HashMap<WayID, Way>) -> N
 }
 
 fn calculate_length_meters(pts: &[Position]) -> f64 {
-    let line_string =
-        LineString::<f64>::from(pts.iter().map(|pt| pt.to_degrees()).collect::<Vec<_>>());
+    let line_string = LineString::from(pts.iter().map(|pt| pt.to_degrees()).collect::<Vec<_>>());
     line_string.haversine_length()
 }
 


### PR DESCRIPTION
You can now set a numeric `weight` property per input `Point` for origins and destinations. If this is missing, it uses 1 by default. Everything should work, but I haven't tested end-to-end -- #77 will remain open until we have a real example demonstrating this.

@Robinlovelace, please feel free to try this out and let me know if you hit any snags.